### PR TITLE
avoid setting socket listen backlog to 1, handle more concurrent conns

### DIFF
--- a/pyseidon/__init__.py
+++ b/pyseidon/__init__.py
@@ -130,7 +130,7 @@ class Pyseidon(object):
             os.umask(umask)
         atexit.register(self._remove_socket)
 
-        self.sock.listen(1)
+        self.sock.listen()
         print('[{}] Pyseidon master booted'.format(os.getpid()), file=sys.stderr)
 
     def _accept(self):

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.1.3',
+    version='0.1.4',
 
     description='A boot-once, run-many-times framework for Python',
     long_description='Pyseidon allows you to boot a Python master process, and then run clients that are forked directly from the master. This is particularly useful for completing a slow data-loading process once and then running many experiments.',


### PR DESCRIPTION
On MacOS, with listen(1), when starting more than ~3 concurrent clients, new clients often get ECONNREFUSED as it can take few ms for the server to accept() each connection. By not setting the backlog in listen(), it seems to handle even 1000 concurrent connections just fine. 
Tested also on Linux, where it behaves the same with and without the param.